### PR TITLE
Fix image paste for Firefox

### DIFF
--- a/main.js
+++ b/main.js
@@ -284,7 +284,7 @@ jQuery(function ($) {
  
                             // get the image content and process it
                             var blob = clipboardItem.getAsFile();
-                            var blobUrl = window.webkitURL.createObjectURL(blob);
+                            var blobUrl = (window.webkitURL || window.URL).createObjectURL(blob);
                             processLoadedImg(blobUrl);
                         } else {
                             console.log("Not supported: " + type);


### PR DESCRIPTION
Image pasting fails on Firefox because it implements `window.URL` not `window.webkitURL` 🤷‍♂ .

See: https://stackoverflow.com/questions/11277677/how-to-choose-between-window-url-createobjecturl-and-window-webkiturl-creat